### PR TITLE
Keep long messages from spilling off the bottom of the banner

### DIFF
--- a/Library/JCNotificationBannerView.m
+++ b/Library/JCNotificationBannerView.m
@@ -102,6 +102,12 @@ const CGFloat kJCNotificationBannerViewMarginY = 5.0;
   }
   self.messageLabel.frame = CGRectMake(currentX, currentY, contentWidth, (self.frame.size.height - borderY) - currentY);
   [self.messageLabel sizeToFit];
+  CGRect messageFrame = self.messageLabel.frame;
+  CGFloat spillY = (currentY + messageFrame.size.height + kJCNotificationBannerViewMarginY) - self.frame.size.height;
+  if (spillY > 0.0) {
+    messageFrame.size.height -= spillY;
+    self.messageLabel.frame = messageFrame;
+  }
 }
 
 - (void) setNotificationBanner:(JCNotificationBanner*)notification {


### PR DESCRIPTION
Restrict the height of the `messageLabel` to be the remaining height in the banner, less the Y margin.
