### PR TITLE
Improved subclassing support for JCNotificationCenter

### DIFF
--- a/Library/JCNotificationCenter.m
+++ b/Library/JCNotificationCenter.m
@@ -22,7 +22,7 @@
     enqueuedNotifications = [NSMutableArray new];
     isPresentingMutex = [NSLock new];
     notificationQueueMutex = [NSObject new];
-    self.presenter = [JCNotificationBannerPresenterIOSStyle new];
+    self.presenter = [[[self class] presenterClass] new];
   }
   return self;
 }
@@ -31,9 +31,13 @@
   static JCNotificationCenter* sharedCenter = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    sharedCenter = [JCNotificationCenter new];
+    sharedCenter = [[self class] new];
   });
   return sharedCenter;
+}
+
++ (Class)presenterClass {
+    return [JCNotificationBannerPresenterIOSStyle class];
 }
 
 /** Adds notification with iOS banner Style to queue with given parameters. */


### PR DESCRIPTION
This makes it easier to subclass JCNotificationCenter. Useful for setting a Banner Presenter style without having to set properties on the singleton class at runtime.
