### PR TITLE
Banner Timeout Implemented

### DIFF
--- a/Library/JCNotificationBanner.h
+++ b/Library/JCNotificationBanner.h
@@ -13,8 +13,8 @@ typedef void (^JCNotificationBannerTapHandlingBlock)();
                                 message:(NSString*)message
                              tapHandler:(JCNotificationBannerTapHandlingBlock)tapHandler;
 
-- (JCNotificationBanner*) initWithTitle:(NSString *)title
-                                message:(NSString *)message
+- (JCNotificationBanner*) initWithTitle:(NSString*)title
+                                message:(NSString*)message
                                 timeout:(NSTimeInterval)timeout
                              tapHandler:(JCNotificationBannerTapHandlingBlock)tapHandler;
 @end

--- a/Library/JCNotificationBanner.m
+++ b/Library/JCNotificationBanner.m
@@ -15,8 +15,8 @@
 }
 
 
-- (JCNotificationBanner*) initWithTitle:(NSString *)_title
-                                message:(NSString *)_message
+- (JCNotificationBanner*) initWithTitle:(NSString*)_title
+                                message:(NSString*)_message
                                 timeout:(NSTimeInterval)_timeout
                              tapHandler:(JCNotificationBannerTapHandlingBlock)_tapHandler {
   

--- a/Library/JCNotificationBannerPresenterIOSStyle.m
+++ b/Library/JCNotificationBannerPresenterIOSStyle.m
@@ -76,7 +76,7 @@
   [containerView.layer addSublayer:imageLayer];
 
   // On timeout, slide it up while fading it out.
-  if (notification.timeout > 0) {
+  if (notification.timeout > 0.0) {
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, notification.timeout * NSEC_PER_SEC);
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
       // Add image of background to layer.

--- a/Library/JCNotificationBannerPresenterSmokeStyle.m
+++ b/Library/JCNotificationBannerPresenterSmokeStyle.m
@@ -73,7 +73,7 @@
 
 
   // On timeout, slide it up while fading it out.
-  if (notification.timeout > 0.) {
+  if (notification.timeout > 0.0) {
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, notification.timeout * NSEC_PER_SEC);
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
       [UIView animateWithDuration:0.5 delay:0 options:UIViewAnimationOptionCurveEaseIn

--- a/Library/JCNotificationCenter.h
+++ b/Library/JCNotificationCenter.h
@@ -14,6 +14,10 @@
                               message:(NSString*)message
                            tapHandler:(JCNotificationBannerTapHandlingBlock)tapHandler;
 
+- (void) enqueueNotificationWithTitle:(NSString*)title
+                              message:(NSString*)message
+                           tapHandler:(JCNotificationBannerTapHandlingBlock)tapHandler;
+
 - (void) enqueueNotification:(JCNotificationBanner*)notification;
 
 @end

--- a/Library/JCNotificationCenter.m
+++ b/Library/JCNotificationCenter.m
@@ -36,22 +36,32 @@
   return sharedCenter;
 }
 
-+ (Class)presenterClass {
-    return [JCNotificationBannerPresenterIOSStyle class];
++ (Class) presenterClass {
+  return [JCNotificationBannerPresenterIOSStyle class];
 }
 
 /** Adds notification with iOS banner Style to queue with given parameters. */
 + (void) enqueueNotificationWithTitle:(NSString*)title
                               message:(NSString*)message
                            tapHandler:(JCNotificationBannerTapHandlingBlock)tapHandler {
-  JCNotificationBanner *notification = [[JCNotificationBanner alloc] initWithTitle:title
+  JCNotificationBanner* notification = [[JCNotificationBanner alloc] initWithTitle:title
                                                                            message:message
                                                                         tapHandler:tapHandler];
   
   [[self sharedCenter] enqueueNotification:notification];
 }
 
-- (void)enqueueNotification:(JCNotificationBanner*)notification {
+- (void) enqueueNotificationWithTitle:(NSString*)title
+                              message:(NSString*)message
+                           tapHandler:(JCNotificationBannerTapHandlingBlock)tapHandler {
+  JCNotificationBanner* notification = [[JCNotificationBanner alloc]
+                                        initWithTitle:title
+                                        message:message
+                                        tapHandler:tapHandler];
+  [self enqueueNotification:notification];
+}
+
+- (void) enqueueNotification:(JCNotificationBanner*)notification {
   @synchronized(notificationQueueMutex) {
     [enqueuedNotifications addObject:notification];
   }

--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,10 @@ Usage?
        }];
     }
 
+By default the banner style is iOS style, which presents banners with a 3D rotation. The project comes with an alternative Smoke appearance, which slides a semi-translucent window down from the status bar. If you want to use the same style for all notifications in your project, you can set the style at compile time by overriding or editing the `+presenterClass` method in JCNotificationCenter.
+
+Notifications enqueued with the method `+enqueueNotificationWithTitle:message:tapHandler:` will time out in five seconds. You can change this on a per-notification basis by setting the timeout property in JCNotificationBanner and enqueing the banner with `-enqueueNotification:`. A value <= 0 will never timeout and requires user interaction to dismiss.
+
 Installation?
 -------------
 


### PR DESCRIPTION
Adds a timeout value to JCNotificationBanner:

We wanted some of the notifications to require user interaction to dismiss, and some to automatically dismiss after some timeout period. This is an overview of the changes we made to implement that.
- New timeout property in JCNotificationBanner
- Timeout value > 0 willl automatically dismiss the notification in that number of seconds. Otherwise it remains until the user dismisses it.
- New "designated enqueing" method:  `- (void) enqueueNotification:(JCNotificationBanner*)notification;`
  
  All convenience calls can go through that and the appropriate locks are in effect. This allows any arbitrary notification to be enqueued. Subclasses and categories can use this method to implement convenience methods with alternate set of parameters. We created one that takes a timeout parameter, for example.
- Existing convenience class method is unchanged. 
  `+enqueueNotificationWithTitle:message:tapHandler:`
  The timeout value is the one defined in the banner class (now set at 5.0 seconds).

Net effect is that the code should be backward compatible, but you can set a timeout on specific notification if you want to.

In our tree this is applied on top of the previous pull request (#16), but the changes should be independent.
