### PR TITLE
Fixed presenters going off screen when app status bar is hidden

### DIFF
--- a/Library/JCNotificationBannerPresenterIOSStyle.m
+++ b/Library/JCNotificationBannerPresenterIOSStyle.m
@@ -29,7 +29,7 @@
   CGSize statusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
   CGFloat width = 320.0;
   CGFloat height = 60.0;
-  CGFloat x = (MAX(statusBarSize.width, statusBarSize.height) - width) / 2.0;
+  CGFloat x = [[UIApplication sharedApplication]isStatusBarHidden] ? [[UIScreen mainScreen]bounds].size.width/2 - width/2 : (MAX(statusBarSize.width, statusBarSize.height) - width) / 2.0;
   CGFloat y = -60.0;
   banner.frame = CGRectMake(x, y, width, height);
 

--- a/Library/JCNotificationBannerPresenterSmokeStyle.m
+++ b/Library/JCNotificationBannerPresenterSmokeStyle.m
@@ -38,7 +38,7 @@
   // up to self.bannerMaxWidth.
   CGSize bannerSize = CGSizeMake(MIN(self.bannerMaxWidth, originalControllerView.bounds.size.width - self.minimumHorizontalMargin * 2.0), self.bannerHeight);
   // Center the banner horizontally.
-  CGFloat x = (MAX(statusBarSize.width, statusBarSize.height) / 2) - (bannerSize.width / 2);
+  CGFloat x = [[UIApplication sharedApplication]isStatusBarHidden] ? [[UIScreen mainScreen]bounds].size.width/2 - bannerSize.width/2 : (MAX(statusBarSize.width, statusBarSize.height) / 2) - (bannerSize.width / 2);
   // Position the banner offscreen vertically.
   CGFloat y = -self.bannerHeight;
 


### PR DESCRIPTION
If the person had the status bar hidden as default the values it
calculated its position off would be zero, so the presenter would be
off screen, this takes this into account.
