### PR TITLE
Handle new iOS 8 orientation enum value

### DIFF
--- a/Library/JCNotificationBannerPresenterIOSStyle.m
+++ b/Library/JCNotificationBannerPresenterIOSStyle.m
@@ -161,6 +161,7 @@
       break;
 
     case UIInterfaceOrientationPortrait:
+    case UIInterfaceOrientationUnknown:
       break;
 
     case UIInterfaceOrientationPortraitUpsideDown:


### PR DESCRIPTION
I don't know what "<a href="https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplication_Class/index.html#//apple_ref/c/econst/UIInterfaceOrientationUnknown">unknown</a>" orientation is, but there's a build warning now!

<img src="http://cl.ly/image/3h1C3D3U3n1y/Screen%20Shot%202014-09-22%20at%2016.35.16.png">
