### PR TITLE
Fix for banner display position when status bar is hidden

### DIFF
--- a/Library/JCNotificationBannerPresenterIOS7Style.m
+++ b/Library/JCNotificationBannerPresenterIOS7Style.m
@@ -33,6 +33,10 @@
   [banner getCurrentPresentingStateAndAtomicallySetPresentingState:YES];
 
   CGSize statusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
+  // if the status bar is hidden it has size 0, so pretend it's the width of the display window
+  if(CGSizeEqualToSize(statusBarSize, CGSizeZero)) {
+    statusBarSize = CGSizeMake(window.bounds.size.width, statusBarSize.height);
+  }
   // Make the banner fill the width of the screen, minus any requested margins,
   // up to self.bannerMaxWidth.
   CGSize bannerSize = CGSizeMake(MIN(self.bannerMaxWidth, originalControllerView.bounds.size.width), self.bannerHeight);

--- a/Library/JCNotificationBannerPresenterIOSStyle.m
+++ b/Library/JCNotificationBannerPresenterIOSStyle.m
@@ -27,6 +27,10 @@
   [banner getCurrentPresentingStateAndAtomicallySetPresentingState:YES];
 
   CGSize statusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
+  // if the status bar is hidden it has size 0, so pretend it's the width of the display window
+  if(CGSizeEqualToSize(statusBarSize, CGSizeZero)) {
+    statusBarSize = CGSizeMake(window.bounds.size.width, statusBarSize.height);
+  }  
   CGFloat width = 320.0;
   CGFloat height = 60.0;
   CGFloat x = (MAX(statusBarSize.width, statusBarSize.height) - width) / 2.0;

--- a/Library/JCNotificationBannerPresenterSmokeStyle.m
+++ b/Library/JCNotificationBannerPresenterSmokeStyle.m
@@ -34,6 +34,10 @@
   [banner getCurrentPresentingStateAndAtomicallySetPresentingState:YES];
 
   CGSize statusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
+  // if the status bar is hidden it has size 0, so pretend it's the width of the display window
+  if(CGSizeEqualToSize(statusBarSize, CGSizeZero)) {
+    statusBarSize = CGSizeMake(window.bounds.size.width, statusBarSize.height);
+  }
   // Make the banner fill the width of the screen, minus any requested margins,
   // up to self.bannerMaxWidth.
   CGSize bannerSize = CGSizeMake(MIN(self.bannerMaxWidth, originalControllerView.bounds.size.width - self.minimumHorizontalMargin * 2.0), self.bannerHeight);


### PR DESCRIPTION
could also consider [[UIApplication sharedApplication] statusBarHidden] instead of checking for CGSizeZero?

maybe remove reliance on the status bar entirely and just center the banner in the parent window?
