### PR TITLE
Fix iOS7 and Smoke notifications when call / hotspot bar displayed

### DIFF
--- a/Library/JCNotificationBannerPresenterIOS7Style.m
+++ b/Library/JCNotificationBannerPresenterIOS7Style.m
@@ -55,6 +55,11 @@
   if (accountForStatusBarHeight) {
     y -= (MIN(statusBarSize.width, statusBarSize.height));
   }
+    
+  CGFloat statusBarHeight = (MIN(statusBarSize.width, statusBarSize.height));
+  if (statusBarHeight > kJCNotificationStandardStatusBarHeight + 1) {
+    y -= (statusBarHeight - kJCNotificationStandardStatusBarHeight);
+  }
 
   banner.frame = CGRectMake(x, y, bannerSize.width, bannerSize.height);
 

--- a/Library/JCNotificationBannerPresenterSmokeStyle.m
+++ b/Library/JCNotificationBannerPresenterSmokeStyle.m
@@ -56,6 +56,11 @@
   if (accountForStatusBarHeight) {
     y -= (MIN(statusBarSize.width, statusBarSize.height));
   }
+    
+  CGFloat statusBarHeight = (MIN(statusBarSize.width, statusBarSize.height));
+  if (statusBarHeight > kJCNotificationStandardStatusBarHeight + 1) {
+    y -= (statusBarHeight - kJCNotificationStandardStatusBarHeight);
+  }
 
   banner.frame = CGRectMake(x, y, bannerSize.width, bannerSize.height);
 

--- a/Library/JCNotificationBannerPresenter_Private.h
+++ b/Library/JCNotificationBannerPresenter_Private.h
@@ -2,6 +2,8 @@
 #import "JCNotificationBannerWindow.h"
 #import "JCNotificationBannerView.h"
 
+const CGFloat kJCNotificationStandardStatusBarHeight = 20.0;
+
 @interface JCNotificationBannerPresenter () {
   @private
   JCNotificationBannerWindow* bannerWindow;

--- a/Library/JCNotificationBannerPresenter_Private.h
+++ b/Library/JCNotificationBannerPresenter_Private.h
@@ -2,7 +2,7 @@
 #import "JCNotificationBannerWindow.h"
 #import "JCNotificationBannerView.h"
 
-const CGFloat kJCNotificationStandardStatusBarHeight = 20.0;
+static const CGFloat kJCNotificationStandardStatusBarHeight = 20.0;
 
 @interface JCNotificationBannerPresenter () {
   @private


### PR DESCRIPTION
I don't have access to any iOS 6 device / simulator so I haven't been able to test this there but I can confirm that on iOS 7 & 8 this fixes the banner so that it appears from the top of the screen.

I didn't know how to fix the rotating iOS 6 style banner presenter.

I attempted to test this in portrait and landscape orientations, but even without this change, the demo project is very broken for me when run in landscape orientation. All of the types of notifications display off screen.